### PR TITLE
Compare all languages

### DIFF
--- a/src/Comparer/CompareAllLanguages.php
+++ b/src/Comparer/CompareAllLanguages.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Goedemiddag\LaravelMissingTranslations\Comparer;
+
+use Goedemiddag\LaravelMissingTranslations\Language;
+use Goedemiddag\LaravelMissingTranslations\MissingTranslation;
+
+class CompareAllLanguages extends Comparer
+{
+    /**
+     * @phpstan-param array<string, Language> $languages
+     */
+    public function handle(array $languages, array $options): void
+    {
+        foreach ($languages as $baseLocale) {
+            $baseLanguageFiles = $baseLocale->fileNames();
+
+            foreach ($baseLanguageFiles as $languageFile) {
+                $baseLanguageFile = $baseLocale->getFile($languageFile);
+
+                foreach ($languages as $language) {
+                    /*
+                     * Check whether the second language is not actually the base language
+                     */
+                    if ($baseLocale->identifier === $language->identifier) {
+                        continue;
+                    }
+
+                    /*
+                     * Check if the file exists in the second language
+                     */
+                    if (!$language->hasFile($languageFile)) {
+                        MissingTranslation::file($languageFile, $language->identifier);
+                        continue;
+                    }
+
+                    $secondLanguageFile = $language->getFile($languageFile);
+
+                    /** @phpstan-ignore-next-line */
+                    foreach ($this->arrayDiffRecursive($baseLanguageFile, $secondLanguageFile) as $missingKey) {
+                        MissingTranslation::key($languageFile, $missingKey, $language->identifier);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/FindMissingTranslationsCommand.php
+++ b/src/FindMissingTranslationsCommand.php
@@ -34,16 +34,14 @@ class FindMissingTranslationsCommand extends Command
         $this->comparer->handle($languages, $this->options());
 
         if (MissingTranslation::isNotEmpty()) {
-            $languages = MissingTranslation::languages();
-
             $this->table(
-                ['File', 'Key', ...$languages],
+                ['File', 'Key', ...array_map(fn (Language $language) => $language->identifier, $languages)],
                 array_map(function (MissingTranslation $translation) use ($languages) {
                     return [
                         $translation->file,
                         $translation->key,
-                        ...array_map(function (string $language) use ($translation) {
-                            return $translation->isMissingInLanguage($language) ? '<error> X </error>' : '';
+                        ...array_map(function (Language $language) use ($translation) {
+                            return $translation->isMissingInLanguage($language->identifier) ? '<error> X </error>' : '<bg=green>   </>';
                         }, $languages),
                     ];
                 }, MissingTranslation::all())


### PR DESCRIPTION
Compares the translations of all languages against all other languages.

To enable, set the `comparer` to `\Goedemiddag\LaravelMissingTranslations\Comparer\CompareAllLanguages::class`

<img width="305" alt="image" src="https://user-images.githubusercontent.com/4411748/219689916-833a0620-4a2d-48b0-b157-2644b92b1fe4.png">
